### PR TITLE
Salesman's Travel

### DIFF
--- a/src/main/java/codewars/tasks/java/salesmantravel/Travel.java
+++ b/src/main/java/codewars/tasks/java/salesmantravel/Travel.java
@@ -1,0 +1,35 @@
+package codewars.tasks.java.salesmantravel;
+
+import java.util.ArrayList;
+import static java.util.stream.Stream.of;
+
+public class Travel {
+
+    /*
+    A traveling salesman has to visit clients. He got each client's address e.g. "432 Main Long Road St. Louisville OH 43071" as a list.
+The basic zipcode format usually consists of two capital letters followed by a white space and five digits. The list of
+clients to visit was given as a string of all addresses, each separated from the others by a comma, e.g. :
+"123 Main Street St. Louisville OH 43071,432 Main Long Road St. Louisville OH 43071,786 High Street Pollocksville NY 56432".
+To ease his travel he wants to group the list by zipcode.
+Task
+The function travel will take two parameters r (addresses' list of all clients' as a string) and zipcode and returns a string in the following format:
+zipcode:street and town,street and town,.../house number,house number,...
+The street numbers must be in the same order as the streets where they belong.
+If a given zipcode doesn't exist in the list of clients' addresses return "zipcode:/"
+     */
+
+    public static String travel(String r, String zipcode) {
+
+        ArrayList<String> streets = new ArrayList<>();
+        ArrayList<String>  apartments = new ArrayList<>();
+        String filteredAddress;
+
+        of(r.split(",")).filter(s -> zipcode.equals(s.substring(s.length() - 8))).forEach(address -> {
+                    streets.add(address.substring(address.indexOf(' ') + 1, address.length() - 9));
+                    apartments.add(address.substring(0, address.indexOf(' ')));
+                });
+
+        filteredAddress = zipcode + ":" + String.join(",", streets) + "/" + String.join(",", apartments);
+        return filteredAddress;
+    }
+}

--- a/src/test/java/codewars/tasks/java/TravelTest.java
+++ b/src/test/java/codewars/tasks/java/TravelTest.java
@@ -1,0 +1,39 @@
+package codewars.tasks.java;
+
+import codewars.tasks.java.salesmantravel.Travel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TravelTest {
+    String ad = "123 Main Street St. Louisville OH 43071,432 Main Long Road St. Louisville OH 43071,786 High Street Pollocksville NY 56432,"
+            + "54 Holy Grail Street Niagara Town ZP 32908,3200 Main Rd. Bern AE 56210,1 Gordon St. Atlanta RE 13000,"
+            + "10 Pussy Cat Rd. Chicago EX 34342,10 Gordon St. Atlanta RE 13000,58 Gordon Road Atlanta RE 13000,"
+            + "22 Tokyo Av. Tedmondville SW 43098,674 Paris bd. Abbeville AA 45521,10 Surta Alley Goodtown GG 30654,"
+            + "45 Holy Grail Al. Niagara Town ZP 32908,320 Main Al. Bern AE 56210,14 Gordon Park Atlanta RE 13000,"
+            + "100 Pussy Cat Rd. Chicago EX 34342,2 Gordon St. Atlanta RE 13000,5 Gordon Road Atlanta RE 13000,"
+            + "2200 Tokyo Av. Tedmondville SW 43098,67 Paris St. Abbeville AA 45521,11 Surta Avenue Goodtown GG 30654,"
+            + "45 Holy Grail Al. Niagara Town ZP 32918,320 Main Al. Bern AE 56215,14 Gordon Park Atlanta RE 13200,"
+            + "100 Pussy Cat Rd. Chicago EX 34345,2 Gordon St. Atlanta RE 13222,5 Gordon Road Atlanta RE 13001,"
+            + "2200 Tokyo Av. Tedmondville SW 43198,67 Paris St. Abbeville AA 45522,11 Surta Avenue Goodville GG 30655,"
+            + "2222 Tokyo Av. Tedmondville SW 43198,670 Paris St. Abbeville AA 45522,114 Surta Avenue Goodville GG 30655,"
+            + "2 Holy Grail Street Niagara Town ZP 32908,3 Main Rd. Bern AE 56210,77 Gordon St. Atlanta RE 13000";
+
+    String code = "OH 43071,NY 56432,ZP 32908,AE 56210,RE 13000,EX 34342,SW 43098,AA 45521,GG 30654,ZP 32908,AE 56215,RE 13200,EX 34345,"
+            + "RE 13222,RE 13001,SW 43198,AA 45522,GG 30655,XX 32321,YY 45098";
+
+    private static void testing(String actual, String expected) {
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void test1() {
+        System.out.println("Fixed Tests: travel");
+        testing(Travel.travel(ad, "AA 45522"), "AA 45522:Paris St. Abbeville,Paris St. Abbeville/67,670");
+        testing(Travel.travel(ad, "EX 34342"), "EX 34342:Pussy Cat Rd. Chicago,Pussy Cat Rd. Chicago/10,100");
+        testing(Travel.travel(ad, "EX 34345"), "EX 34345:Pussy Cat Rd. Chicago/100");
+        testing(Travel.travel(ad, "AA 45521"), "AA 45521:Paris bd. Abbeville,Paris St. Abbeville/674,67");
+        testing(Travel.travel(ad, "AE 56215"), "AE 56215:Main Al. Bern/320");
+        testing(Travel.travel(ad, "AE 34567"), "AE 34567:/");
+    }
+}


### PR DESCRIPTION
Link to Kata: https://www.codewars.com/kata/56af1a20509ce5b9b000001e/solutions/java

A traveling salesman has to visit clients. He got each client's address e.g. "432 Main Long Road St. Louisville OH 43071" as a list.
The basic zipcode format usually consists of two capital letters followed by a white space and five digits. The list of clients to visit was given as a string of all addresses, each separated from the others by a comma, e.g. :
"123 Main Street St. Louisville OH 43071,432 Main Long Road St. Louisville OH 43071,786 High Street Pollocksville NY 56432".
To ease his travel he wants to group the list by zipcode.
Task
The function travel will take two parameters r (addresses' list of all clients' as a string) and zipcode and returns a string in the following format:
zipcode:street and town,street and town,.../house number,house number,...
The street numbers must be in the same order as the streets where they belong.
If a given zipcode doesn't exist in the list of clients' addresses return "zipcode:/"